### PR TITLE
Fix "lape" definition as a modifier

### DIFF
--- a/data/toki_pona_dictionary.js
+++ b/data/toki_pona_dictionary.js
@@ -512,7 +512,7 @@ toki_pona_dictionary = [
       ],
       [
         "mod",
-        "sleeping, of sleep laso mod blue, blue-green"
+        "sleeping, of sleep"
       ]
     ]
   },


### PR DESCRIPTION
There was additional text relating to "laso" in the definition of "lape" as a modifier: "sleeping, of sleep *laso mod blue, blue-green*"