### PR TITLE
Fix "monsuta" entry

### DIFF
--- a/data/toki_pona_dictionary.js
+++ b/data/toki_pona_dictionary.js
@@ -791,10 +791,6 @@ toki_pona_dictionary = [
     "meanings":[
       [
         "n*",
-        "back, rear end, butt, behind"
-      ],
-      [
-        "mod*",
         "monster, monstrosity, fearful thing, fright, mythical creatures, fear"
       ]
     ]


### PR DESCRIPTION
The *noun* definition of "monsuta" was of "monsi", and the *mod* one was of its noun.