### PR TITLE
Differentiate between whole and partial matches

### DIFF
--- a/src/data/toki_pona_dictionary.json
+++ b/src/data/toki_pona_dictionary.json
@@ -1410,7 +1410,7 @@
     "meanings": [
       [
         "n",
-        "horizontal surface, e.g furniture, table, chair, pillow, floor"
+        "horizontal surface, e.g. furniture, table, chair, pillow, floor"
       ]
     ]
   },

--- a/src/index.pug
+++ b/src/index.pug
@@ -13,15 +13,17 @@ head
   main
     #search-box
       input(type='text' id='search' autofocus='true' placeholder='o lukin' autocorrect='off' autocapitalize='off' spellcheck='false')
+    #exact-results
     .dictionary-words
       each word in dictionary
-        .word
-          .word-name=word.word
-          ul.word-meanings
-            each meaning in word.meanings
-              li.meaning
-                span.speech-type=meaning[0]
-                span=meaning[1]
+        .entry
+          .word
+            .word-name=word.word
+            ul.word-meanings
+              each meaning in word.meanings
+                li.meaning
+                  span.speech-type=meaning[0]
+                  span=meaning[1]
   footer
     p.footer-title Parts of speech
     ul.parts-of-speech

--- a/src/main.js
+++ b/src/main.js
@@ -2,8 +2,9 @@ import './styles/animations.css';
 import './styles/main.css';
 import {ElementSearcher} from './search';
 
-const wordElements = document.querySelectorAll('div[class=word]');
-const searcher = new ElementSearcher(wordElements);
+const wordElements = document.querySelectorAll('div[class=entry]');
+const exactResults = document.querySelector('div[id=exact-results]');
+const searcher = new ElementSearcher(exactResults, wordElements);
 
 const searchElement = document.getElementById('search');
 searchElement.addEventListener('keyup', () => {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -141,11 +141,11 @@ input:-moz-placeholder {
 }
 
 .dictionary-words {
-  margin-top: 50px;
+  margin-top: 0px;
   border-bottom: thin solid snow;
 }
 .word {
-  margin: 2.5em 0;
+  margin: 0.5em;
   display: flex;
   font-weight: 400;
 }
@@ -154,15 +154,23 @@ input:-moz-placeholder {
     display: block;
   }
 }
+.entry {
+ border-radius:2em;
+ margin: 1.5em 0;
+ display:flex;
+}
+.exact-match {
+  background: sienna;
+}
 .word-name {
-  display: block;
+  display: inline-table;
   align-self: center;
   width: 90px;
 }
 .word-meanings {
   display: block;
   align-self: flex-end;
-  width: 400px;
+  width: auto;
   margin: 0;
   padding: 0;
   font-weight: 300;


### PR DESCRIPTION
toki!

Thanks for creating this, I've been using it quite often and
I've noticed this issue with the search results and later found the discussion in #9.

I've tried implementing your idea to clone, pin, and highlight exact whole-word-matches at the top.
(I also have a branch where I didn't clone the nodes and instead moved them to the top)

What I haven't addressed (yet?) is your concern that too many exact matches could bury desired partial matches.

I'm not very experienced with javascript and html/css but I hope this is at least in part helpful.
(especially the CSS was a pain to get good results)

![Screenshot_2021-01-21 Toki Pona Dictionary](https://user-images.githubusercontent.com/6785936/105421287-2bf4ea00-5c42-11eb-82ef-8ec92a0e0e8b.png)


